### PR TITLE
Migrate to the new Airflow CLI command format

### DIFF
--- a/env-setup/set_composer_variables.sh
+++ b/env-setup/set_composer_variables.sh
@@ -32,4 +32,4 @@ gcloud composer environments storage data import \
 gcloud composer environments run \
 ${COMPOSER_ENV_NAME} \
 --location ${COMPOSER_REGION} \
-variables -- --import /home/airflow/gcs/data/${COMPOSER_VAR_FILE}
+variables import -- /home/airflow/gcs/data/${COMPOSER_VAR_FILE}

--- a/source-code/build-pipeline/build_deploy_test.yaml
+++ b/source-code/build-pipeline/build_deploy_test.yaml
@@ -37,7 +37,7 @@ steps:
   dir: '$REPO_NAME/workflow-dag'
   id: 'deploy-test-ref-file'
 - name: gcr.io/cloud-builders/gcloud
-  args: ['composer', 'environments', 'run', '${_COMPOSER_ENV_NAME}', '--location', '${_COMPOSER_REGION}','variables', '--', '--set', 'dataflow_jar_file_test', 'dataflow_deployment_$BUILD_ID.jar']
+  args: ['composer', 'environments', 'run', '${_COMPOSER_ENV_NAME}', '--location', '${_COMPOSER_REGION}', 'variables', 'set', '--', 'dataflow_jar_file_test', 'dataflow_deployment_$BUILD_ID.jar']
   id: 'set-composer-jar-ref'
 - name: gcr.io/cloud-builders/gsutil
   args: ['cp', 'compare_xcom_maps.py', '${_COMPOSER_DAG_BUCKET}']
@@ -53,5 +53,5 @@ steps:
   dir: '$REPO_NAME/build-pipeline'
   id: 'wait-for-dag-deployed-on-composer'
 - name: gcr.io/cloud-builders/gcloud
-  args: ['composer', 'environments', 'run', '${_COMPOSER_ENV_NAME}', '--location', '${_COMPOSER_REGION}', 'trigger_dag', '--', '${_COMPOSER_DAG_NAME_TEST}', '--run_id=$BUILD_ID']
+  args: ['composer', 'environments', 'run', '${_COMPOSER_ENV_NAME}', '--location', '${_COMPOSER_REGION}', 'dags', 'trigger', '--', '${_COMPOSER_DAG_NAME_TEST}', '--run-id=$BUILD_ID']
   id: 'trigger-pipeline-execution'

--- a/source-code/build-pipeline/deploy_prod.yaml
+++ b/source-code/build-pipeline/deploy_prod.yaml
@@ -23,7 +23,7 @@ steps:
   dir: '$REPO_NAME/workflow-dag'
   id: 'deploy-input-file'
 - name: gcr.io/cloud-builders/gcloud
-  args: ['composer', 'environments', 'run', '${_COMPOSER_ENV_NAME}', '--location', '${_COMPOSER_REGION}','variables', '--', '--set', 'dataflow_jar_file_prod', 'dataflow_deployment_$BUILD_ID.jar']
+  args: ['composer', 'environments', 'run', '${_COMPOSER_ENV_NAME}', '--location', '${_COMPOSER_REGION}', 'variables', 'set', '--', 'dataflow_jar_file_prod', 'dataflow_deployment_$BUILD_ID.jar']
   id: 'set-composer-jar-ref'
 - name: gcr.io/cloud-builders/gsutil
   args: ['cp', 'data-pipeline-prod.py', '${_COMPOSER_DAG_BUCKET}']

--- a/source-code/build-pipeline/wait_for_dag_deployed.sh
+++ b/source-code/build-pipeline/wait_for_dag_deployed.sh
@@ -20,7 +20,7 @@ n=0
 until [[ $n -ge $4 ]]
 do
   status=0
-  gcloud composer environments run "${1}" --location "${2}" list_dags \
+  gcloud composer environments run "${1}" --location "${2}" dags list \
   2>&1 | grep "${3}" && break
   status=$?
   n=$(($n+1))


### PR DESCRIPTION
The old format generates a warning. The new format is now supported in `gcloud composer` also in the latest Airflow 1 versions.